### PR TITLE
feat: add install.sh for one-command installation

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgbase=linux-charcoal-616
 _nepbase=linux-neptune-616
-_tag=6.16.12-valve21
+_tag=6.16.12-valve23
 _ver=3
 pkgver=${_tag//-/.}.cc$_ver
 pkgrel=1
@@ -96,7 +96,7 @@ source=(
    6.16-poc-selector-v2.6.1.patch 
    6.16-nap-v0.4.0.patch
 )
-sha256sums=('a69eea3b189ab64e65608140d6cd7c57823d1b39b361e876197eec1b4d1db957'
+sha256sums=('4011d16fef57b8f04cbcddc0937819f7fd32225f65d63698afbd5dc6629d0ff0'
             '37452b4d09e5e42134ae24a61f2f656790837c327268074cf79d7dab3558b972'
             'd88eaf0f94bae470040e4882f334c05b1bb2ab0a99e4b7299aa0b2337810ab8d'
             'fd57213c524e24cd9c72e2fecd9b2005934b6099e209864e5a93eb03406fca21'

--- a/README.md
+++ b/README.md
@@ -61,7 +61,13 @@ Charcoal is an optimized Linux kernel for Steam Deck, Asus ROG Ally, and other A
 
 ## Install
 
-Download the [latest release](https://github.com/V10lator/linux-charcoal/releases/latest) and run the following on your device:
+Run the following on your device to automatically download and install the latest release:
+
+```bash
+curl -L https://github.com/V10lator/linux-charcoal/raw/master/install.sh | bash
+```
+
+Or manually download the [latest release](https://github.com/V10lator/linux-charcoal/releases/latest) and run:
 
 ```bash
 cd ~/Downloads

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Or manually:
 
 ```bash
 sudo steamos-devmode enable --no-prompt
-_neptune=$(pacman -Qi $(pacman -Qq | grep '^linux-charcoal' | grep -v headers | head -1) | awk '/^Replaces/{print $3}')
+_neptune=$(pacman -Qi $(pacman -Qq | grep '^linux-charcoal' | grep -v headers | head -1) | grep '^Replaces' | tr ' ' '\n' | grep '^linux-neptune' | head -1)
 sudo pacman -Rsn $(pacman -Qq | grep '^linux-charcoal')
 sudo pacman -S "$_neptune"
 sudo grub-mkconfig -o /efi/EFI/steamos/grub.cfg

--- a/README.md
+++ b/README.md
@@ -93,7 +93,13 @@ You can also verify in Gaming Mode under **Settings → System**, where the kern
 
 ## Uninstall
 
-To remove Charcoal and return to the stock Neptune kernel:
+Run the following to automatically remove Charcoal and restore the Neptune kernel:
+
+```bash
+curl -L https://github.com/V10lator/linux-charcoal/raw/master/uninstall.sh | bash
+```
+
+Or manually:
 
 ```bash
 sudo steamos-readonly disable

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ Or manually download the [latest release](https://github.com/V10lator/linux-char
 
 ```bash
 cd ~/Downloads
-sudo steamos-readonly disable
-sudo pacman -U linux-charcoal-*-x86_64.pkg.tar.zst  # Confirm when asked to remove linux-neptune-*
-sudo steamos-readonly enable
+sudo steamos-devmode enable --no-prompt
+pacman -Qq | grep '^linux-neptune' | xargs -r sudo pacman -Rns --noconfirm
+sudo pacman -U linux-charcoal-*-x86_64.pkg.tar.zst
+sudo grub-mkconfig -o /efi/EFI/steamos/grub.cfg
 rm linux-charcoal*
 ```
 
@@ -102,11 +103,11 @@ curl -L https://github.com/V10lator/linux-charcoal/raw/master/uninstall.sh | bas
 Or manually:
 
 ```bash
-sudo steamos-readonly disable
-_neptune=$(pacman -Qi $(pacman -Qq 'linux-charcoal*') | awk '/^Replaces/{print $3}')
-sudo pacman -Rsn $(pacman -Qq 'linux-charcoal*')
+sudo steamos-devmode enable --no-prompt
+_neptune=$(pacman -Qi $(pacman -Qq | grep '^linux-charcoal' | grep -v headers | head -1) | awk '/^Replaces/{print $3}')
+sudo pacman -Rsn $(pacman -Qq | grep '^linux-charcoal')
 sudo pacman -S "$_neptune"
-sudo steamos-readonly enable
+sudo grub-mkconfig -o /efi/EFI/steamos/grub.cfg
 ```
 
 Then reboot.

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ echo "Downloading headers..."
 curl -L "$HEADERS_URL" -o /tmp/linux-charcoal-headers.pkg.tar.zst
 
 echo "Enabling dev mode (disables read-only filesystem and initialises keyring)..."
-sudo steamos-devmode enable
+sudo steamos-devmode enable --no-prompt
 
 echo "Removing existing Neptune kernel..."
 pacman -Qq 2>/dev/null | grep '^linux-neptune' | xargs -r sudo pacman -Rns --noconfirm
@@ -33,8 +33,8 @@ sudo pacman -U --noconfirm /tmp/linux-charcoal.pkg.tar.zst /tmp/linux-charcoal-h
 echo "Updating GRUB..."
 sudo grub-mkconfig -o /efi/EFI/steamos/grub.cfg
 
-echo "Disabling dev mode..."
-sudo steamos-devmode disable
+echo "Re-enabling read-only filesystem..."
+sudo steamos-readonly enable
 
 echo "Cleaning up..."
 rm -f /tmp/linux-charcoal*.pkg.tar.zst

--- a/install.sh
+++ b/install.sh
@@ -25,10 +25,19 @@ echo "Enabling dev mode (disables read-only filesystem and initialises keyring).
 sudo steamos-devmode enable --no-prompt
 
 echo "Removing existing Neptune kernel..."
-pacman -Qq 2>/dev/null | grep '^linux-neptune' | xargs -r sudo pacman -Rns --noconfirm
+_original_neptune=$(pacman -Qq | grep '^linux-neptune' | grep -v headers | head -1)
+pacman -Qq | grep '^linux-neptune' | xargs -r sudo pacman -Rns --noconfirm
 
 echo "Installing Charcoal kernel..."
-sudo pacman -U --noconfirm /tmp/linux-charcoal.pkg.tar.zst /tmp/linux-charcoal-headers.pkg.tar.zst
+if ! sudo pacman -U --noconfirm /tmp/linux-charcoal.pkg.tar.zst /tmp/linux-charcoal-headers.pkg.tar.zst; then
+  echo "Install failed — restoring original Neptune kernel..."
+  sudo pacman -S --noconfirm "$_original_neptune"
+  rm -f /tmp/linux-charcoal*.pkg.tar.zst
+  exit 1
+fi
+
+# Save original neptune for uninstall script to restore correctly
+echo "$_original_neptune" | sudo tee /etc/charcoal-original-neptune > /dev/null
 
 echo "Updating GRUB..."
 sudo grub-mkconfig -o /efi/EFI/steamos/grub.cfg

--- a/install.sh
+++ b/install.sh
@@ -33,9 +33,6 @@ sudo pacman -U --noconfirm /tmp/linux-charcoal.pkg.tar.zst /tmp/linux-charcoal-h
 echo "Updating GRUB..."
 sudo grub-mkconfig -o /efi/EFI/steamos/grub.cfg
 
-echo "Re-enabling read-only filesystem..."
-sudo steamos-readonly enable
-
 echo "Cleaning up..."
 rm -f /tmp/linux-charcoal*.pkg.tar.zst
 

--- a/install.sh
+++ b/install.sh
@@ -21,11 +21,11 @@ curl -L "$PKG_URL" -o /tmp/linux-charcoal.pkg.tar.zst
 echo "Downloading headers..."
 curl -L "$HEADERS_URL" -o /tmp/linux-charcoal-headers.pkg.tar.zst
 
-echo "Disabling read-only filesystem..."
-sudo steamos-readonly disable
+echo "Enabling dev mode (disables read-only filesystem and initialises keyring)..."
+sudo steamos-devmode enable
 
 echo "Removing existing Neptune kernel..."
-pacman -Qq 'linux-neptune*' 2>/dev/null | xargs -r sudo pacman -Rns --noconfirm
+pacman -Qq 2>/dev/null | grep '^linux-neptune' | xargs -r sudo pacman -Rns --noconfirm
 
 echo "Installing Charcoal kernel..."
 sudo pacman -U --noconfirm /tmp/linux-charcoal.pkg.tar.zst /tmp/linux-charcoal-headers.pkg.tar.zst
@@ -33,8 +33,8 @@ sudo pacman -U --noconfirm /tmp/linux-charcoal.pkg.tar.zst /tmp/linux-charcoal-h
 echo "Updating GRUB..."
 sudo grub-mkconfig -o /efi/EFI/steamos/grub.cfg
 
-echo "Re-enabling read-only filesystem..."
-sudo steamos-readonly enable
+echo "Disabling dev mode..."
+sudo steamos-devmode disable
 
 echo "Cleaning up..."
 rm -f /tmp/linux-charcoal*.pkg.tar.zst

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/bash
+
+if [ "$EUID" -eq 0 ]; then
+  echo "Please do not run as root"
+  exit 1
+fi
+
+echo "Fetching latest Charcoal release..."
+RELEASE_JSON=$(curl -s https://api.github.com/repos/V10lator/linux-charcoal/releases/latest)
+PKG_URL=$(echo "$RELEASE_JSON" | grep "browser_download_url" | grep -v "headers" | grep "x86_64.pkg.tar.zst" | cut -d '"' -f 4)
+HEADERS_URL=$(echo "$RELEASE_JSON" | grep "browser_download_url" | grep "headers" | grep "x86_64.pkg.tar.zst" | cut -d '"' -f 4)
+
+if [ -z "$PKG_URL" ] || [ -z "$HEADERS_URL" ]; then
+  echo "Failed to fetch release URLs"
+  exit 1
+fi
+
+echo "Downloading kernel..."
+curl -L "$PKG_URL" -o /tmp/linux-charcoal.pkg.tar.zst
+
+echo "Downloading headers..."
+curl -L "$HEADERS_URL" -o /tmp/linux-charcoal-headers.pkg.tar.zst
+
+echo "Disabling read-only filesystem..."
+sudo steamos-readonly disable
+
+echo "Removing existing Neptune kernel..."
+pacman -Qq 'linux-neptune*' 2>/dev/null | xargs -r sudo pacman -Rns --noconfirm
+
+echo "Installing Charcoal kernel..."
+sudo pacman -U --noconfirm /tmp/linux-charcoal.pkg.tar.zst /tmp/linux-charcoal-headers.pkg.tar.zst
+
+echo "Updating GRUB..."
+sudo grub-mkconfig -o /efi/EFI/steamos/grub.cfg
+
+echo "Re-enabling read-only filesystem..."
+sudo steamos-readonly enable
+
+echo "Cleaning up..."
+rm -f /tmp/linux-charcoal*.pkg.tar.zst
+
+echo ""
+echo "Done! Reboot to use the Charcoal kernel."
+echo "Verify after reboot with: uname -a"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/bash
+
+if [ "$EUID" -eq 0 ]; then
+  echo "Please do not run as root"
+  exit 1
+fi
+
+if ! pacman -Qq 'linux-charcoal*' &>/dev/null; then
+  echo "Charcoal kernel is not installed"
+  exit 1
+fi
+
+echo "Detecting matching Neptune kernel..."
+_neptune=$(pacman -Qi $(pacman -Qq 'linux-charcoal*' | grep -v headers | head -1) | awk '/^Replaces/{print $3}')
+
+if [ -z "$_neptune" ]; then
+  echo "Failed to detect matching Neptune kernel"
+  exit 1
+fi
+
+echo "Will reinstall: $_neptune"
+
+echo "Disabling read-only filesystem..."
+sudo steamos-readonly disable
+
+echo "Removing Charcoal kernel..."
+sudo pacman -Rsn --noconfirm $(pacman -Qq 'linux-charcoal*')
+
+echo "Reinstalling Neptune kernel..."
+sudo pacman -S --noconfirm "$_neptune"
+
+echo "Updating GRUB..."
+sudo grub-mkconfig -o /efi/EFI/steamos/grub.cfg
+
+echo "Re-enabling read-only filesystem..."
+sudo steamos-readonly enable
+
+echo ""
+echo "Done! Reboot to return to the Neptune kernel."
+echo "Verify after reboot with: uname -a"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -10,15 +10,20 @@ if ! pacman -Qq | grep -q '^linux-charcoal'; then
   exit 1
 fi
 
-echo "Detecting matching Neptune kernel..."
-_neptune=$(pacman -Qi $(pacman -Qq | grep '^linux-charcoal' | grep -v headers | head -1) | awk '/^Replaces/{print $3}')
-
-if [ -z "$_neptune" ]; then
-  echo "Failed to detect matching Neptune kernel"
-  exit 1
+# Use the originally installed neptune saved during install if available,
+# otherwise fall back to the series from Charcoal's Replaces field
+if [ -f /etc/charcoal-original-neptune ]; then
+  _neptune=$(cat /etc/charcoal-original-neptune)
+  echo "Restoring originally installed Neptune kernel: $_neptune"
+else
+  _neptune=$(pacman -Qi $(pacman -Qq | grep '^linux-charcoal' | grep -v headers | head -1) | awk '/^Replaces/{print $3}')
+  echo "Will reinstall: $_neptune (original not recorded, using Charcoal's Replaces field)"
 fi
 
-echo "Will reinstall: $_neptune"
+if [ -z "$_neptune" ]; then
+  echo "Failed to detect Neptune kernel to restore"
+  exit 1
+fi
 
 echo "Enabling dev mode (disables read-only filesystem and initialises keyring)..."
 sudo steamos-devmode enable --no-prompt
@@ -32,8 +37,7 @@ sudo pacman -S --noconfirm "$_neptune"
 echo "Updating GRUB..."
 sudo grub-mkconfig -o /efi/EFI/steamos/grub.cfg
 
-echo "Re-enabling read-only filesystem..."
-sudo steamos-readonly enable
+sudo rm -f /etc/charcoal-original-neptune
 
 echo ""
 echo "Done! Reboot to return to the Neptune kernel."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -5,13 +5,13 @@ if [ "$EUID" -eq 0 ]; then
   exit 1
 fi
 
-if ! pacman -Qq 'linux-charcoal*' &>/dev/null; then
+if ! pacman -Qq | grep -q '^linux-charcoal'; then
   echo "Charcoal kernel is not installed"
   exit 1
 fi
 
 echo "Detecting matching Neptune kernel..."
-_neptune=$(pacman -Qi $(pacman -Qq 'linux-charcoal*' | grep -v headers | head -1) | awk '/^Replaces/{print $3}')
+_neptune=$(pacman -Qi $(pacman -Qq | grep '^linux-charcoal' | grep -v headers | head -1) | awk '/^Replaces/{print $3}')
 
 if [ -z "$_neptune" ]; then
   echo "Failed to detect matching Neptune kernel"
@@ -20,11 +20,11 @@ fi
 
 echo "Will reinstall: $_neptune"
 
-echo "Disabling read-only filesystem..."
-sudo steamos-readonly disable
+echo "Enabling dev mode (disables read-only filesystem and initialises keyring)..."
+sudo steamos-devmode enable
 
 echo "Removing Charcoal kernel..."
-sudo pacman -Rsn --noconfirm $(pacman -Qq 'linux-charcoal*')
+sudo pacman -Rsn --noconfirm $(pacman -Qq | grep '^linux-charcoal')
 
 echo "Reinstalling Neptune kernel..."
 sudo pacman -S --noconfirm "$_neptune"
@@ -32,8 +32,8 @@ sudo pacman -S --noconfirm "$_neptune"
 echo "Updating GRUB..."
 sudo grub-mkconfig -o /efi/EFI/steamos/grub.cfg
 
-echo "Re-enabling read-only filesystem..."
-sudo steamos-readonly enable
+echo "Disabling dev mode..."
+sudo steamos-devmode disable
 
 echo ""
 echo "Done! Reboot to return to the Neptune kernel."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -16,7 +16,7 @@ if [ -f /etc/charcoal-original-neptune ]; then
   _neptune=$(cat /etc/charcoal-original-neptune)
   echo "Restoring originally installed Neptune kernel: $_neptune"
 else
-  _neptune=$(pacman -Qi $(pacman -Qq | grep '^linux-charcoal' | grep -v headers | head -1) | awk '/^Replaces/{print $3}')
+  _neptune=$(pacman -Qi $(pacman -Qq | grep '^linux-charcoal' | grep -v headers | head -1) | grep '^Replaces' | tr ' ' '\n' | grep '^linux-neptune' | head -1)
   echo "Will reinstall: $_neptune (original not recorded, using Charcoal's Replaces field)"
 fi
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -21,7 +21,7 @@ fi
 echo "Will reinstall: $_neptune"
 
 echo "Enabling dev mode (disables read-only filesystem and initialises keyring)..."
-sudo steamos-devmode enable
+sudo steamos-devmode enable --no-prompt
 
 echo "Removing Charcoal kernel..."
 sudo pacman -Rsn --noconfirm $(pacman -Qq | grep '^linux-charcoal')
@@ -32,8 +32,8 @@ sudo pacman -S --noconfirm "$_neptune"
 echo "Updating GRUB..."
 sudo grub-mkconfig -o /efi/EFI/steamos/grub.cfg
 
-echo "Disabling dev mode..."
-sudo steamos-devmode disable
+echo "Re-enabling read-only filesystem..."
+sudo steamos-readonly enable
 
 echo ""
 echo "Done! Reboot to return to the Neptune kernel."


### PR DESCRIPTION
## Summary

Adds `install.sh` and `uninstall.sh` so users can install or remove Charcoal with a single command — similar to how Decky Loader and Decky plugins are installed.

**Install:**
```bash
curl -L https://github.com/V10lator/linux-charcoal/raw/master/install.sh | bash
```

**Uninstall:**
```bash
curl -L https://github.com/V10lator/linux-charcoal/raw/master/uninstall.sh | bash
```

## Tested

Fully tested on **Asus ROG Ally RC71L** (SteamOS neptune-611 → charcoal-616 → neptune-611). [Logs here.](https://hst.sh/ejivaqafif.coffeescript)

- Install: charcoal-616 boots correctly ✅
- Uninstall: correctly detects and restores original neptune-611 (not neptune-616) ✅
- Fallback: if charcoal install fails after neptune removal, original neptune is reinstalled automatically ✅

## What the scripts handle

- **steamos-devmode enable --no-prompt** — required (not just `steamos-readonly disable`). The headers package pulls signed repo dependencies (`llvm`, `clang`, `lld`, `polly`) which need keyring initialisation.
- **Neptune pre-removal** — removes all `linux-neptune*` packages before installing Charcoal using `pacman -Qq | grep '^linux-neptune'`. Handles any series, avoiding the vmlinuz file conflict.
- **Original neptune saved** — install script saves the originally installed neptune package name to `/etc/charcoal-original-neptune`. Uninstall reads this to restore the exact version the user had, not just the series Charcoal was built against.
- **Install fallback** — if charcoal install fails after neptune removal, the script automatically reinstalls the saved original neptune and exits cleanly.
- **grub-mkconfig** — runs automatically after install and uninstall. Confirmed working: correctly finds `vmlinuz-linux-neptune-616` (charcoal's kernel image name) and writes the right grub entry.
- **README** — manual install and uninstall steps updated to match script behavior.

## Notes

- The `ata_generic`, `virtio_*` and `plymouth` errors during install are harmless — documented in the README.
- Dev mode stays on after install. SteamOS updates reset it anyway.